### PR TITLE
correct output and cleanup syntax

### DIFF
--- a/hw00/src/HW00.hs
+++ b/hw00/src/HW00.hs
@@ -1,4 +1,5 @@
 module HW00 where
 
 greeting :: IO ()
+-- CM: see comments in pull request
 greeting = putStrLn("Hello, World!")


### PR DESCRIPTION
The reason `../bin/check.sh hello` is failing is that your code does not output what the problem requests! Check the problem description and correct the output.

In Haskell, parentheses are generally used for two purposes: to show operator precedence, and to form 'tuples' (which we haven't used yet). Function arguments do not, of themselves, require parentheses.

In this case, you have a function `putStrLn` that takes a single argument, so the parentheses are not needed.